### PR TITLE
fix #1282 correct typo in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ See the [guidelines](docs/contributing.md) for contributing to this project.
 
 This project is governed by a [Code Of Conduct](docs/code_of_conduct.md).
 
-To disclose potential a security vulnerability please see our [security](docs/security.md) documentation.
+To disclose any potential security vulnerability please see our [security](docs/security.md) documentation.
 
 ### Contributors
 


### PR DESCRIPTION
This simply corrects the typo in the readme file, as was mention in #1282